### PR TITLE
login-using-a-smart-card: Do not use a real organization name

### DIFF
--- a/docs/how-to/log-in-using-a-smart-card.md
+++ b/docs/how-to/log-in-using-a-smart-card.md
@@ -264,7 +264,7 @@ Certificates can be associated to users using the card certificate subject, so i
 
 ```bash
 openssl x509 -noout -subject -in card-cert.pem | sed "s/, /,/g;s/ = /=/g"
-subject=C=IT,O=Actalis S.p.A.,OU=REGIONE TOSCANA,SN=TREVISAN,GN=MARCO,CN=TRVMRC[...data-removed...]/6090033068507002.UyMnHxfF3gkAeBYHhxa6V1Edazs=
+subject=C=IT,O=Some Organization,OU=REGIONE TOSCANA,SN=TREVISAN,GN=MARCO,CN=TRVMRC[...data-removed...]/6090033068507002.UyMnHxfF3gkAeBYHhxa6V1Edazs=
 ```
 
 The `sssd.conf` configuration for the user `foo` would be:


### PR DESCRIPTION
Updated the subject in the smart card login documentation to use an invalid organization name, rather an existing registered name.

