### PR TITLE
Update BitLocker instructions with modern Windows Settings path

### DIFF
--- a/docs/how-to/turn-off-bitlocker-in-windows.md
+++ b/docs/how-to/turn-off-bitlocker-in-windows.md
@@ -18,17 +18,11 @@ If you wish to re-encrypt your Windows partition after installing Ubuntu alongsi
 
     Any encryption procedure, hard drive structure change or installation of new operating systems on a hard drive that already contains data can potentially lead to a data loss. Make sure that your personal data is safe. Even simply copying the important files to an external drive minimizes the risk of data loss.
 
-1. In Windows, open Settings and enter *Manage BitLocker* in the search box.
+1. In Windows, open the Settings app and go to {menuselection}`Privacy & Security --> Device Encryption`. Toggle it off.
 
-    Alternatively, go to {menuselection}`Control Panel --> System and Security --> BitLocker Drive Encryption`.
+    On older versions of Windows, go to {menuselection}`Control Panel --> System and Security --> BitLocker Drive Encryption` and click {guilabel}`Turn off BitLocker`.
 
     ![The BitLocker Drive Encryption settings in Windows](/images/bitlocker-drive-encryption.png)
-
-1. If the status is "BitLocker waiting for activation", it means that BitLocker is enabled but your data isn't encrypted yet.
-
-    Enable BitLocker first by clicking {guilabel}`Turn on BitLocker`. Then proceed.
-
-1. Click {guilabel}`Turn off BitLocker`.
 
 1. Windows informs you that it is going to decrypt the data.
 

--- a/docs/how-to/turn-off-bitlocker-in-windows.md
+++ b/docs/how-to/turn-off-bitlocker-in-windows.md
@@ -18,11 +18,27 @@ If you wish to re-encrypt your Windows partition after installing Ubuntu alongsi
 
     Any encryption procedure, hard drive structure change or installation of new operating systems on a hard drive that already contains data can potentially lead to a data loss. Make sure that your personal data is safe. Even simply copying the important files to an external drive minimizes the risk of data loss.
 
-1. In Windows, open the Settings app and go to {menuselection}`Privacy & Security --> Device Encryption`. Toggle it off.
+1. Disable encryption:
 
-    On older versions of Windows, go to {menuselection}`Control Panel --> System and Security --> BitLocker Drive Encryption` and click {guilabel}`Turn off BitLocker`.
+    :::::{tab-set}
+    ::::{tab-item} On Windows 11
+    Open the Settings app and go to {menuselection}`Privacy & Security --> Device Encryption`.
+
+    Toggle it off.
+    ::::
+
+    ::::{tab-item} On earlier Windows releases
+    Go to {menuselection}`Control Panel --> System and Security --> BitLocker Drive Encryption`.
+
+    :::{note}
+    If the status is "BitLocker waiting for activation", it means that BitLocker is enabled but your data isn't encrypted yet. Enable BitLocker first by clicking {guilabel}`Turn on BitLocker`.
+    :::
+
+    Click {guilabel}`Turn off BitLocker` to disable encryption.
 
     ![The BitLocker Drive Encryption settings in Windows](/images/bitlocker-drive-encryption.png)
+    ::::
+    :::::
 
 1. Windows informs you that it is going to decrypt the data.
 


### PR DESCRIPTION

## Summary

- Use the current Windows 11 path (Settings > Privacy & Security > Device Encryption) as the primary instruction for turning off BitLocker
- Demote the Control Panel route to a fallback for older Windows versions
- Remove the now-redundant "waiting for activation" and separate "Turn off BitLocker" steps

## Why

The old "Manage BitLocker" search and Control Panel route can show a blank page on modern Windows 11. The current recommended way to disable BitLocker is through Settings > Privacy & Security > Device Encryption.
