### PR TITLE
Add warning for Ventoy 1.1.11 known issue

### DIFF
--- a/docs/how-to/create-a-bootable-usb-stick.md
+++ b/docs/how-to/create-a-bootable-usb-stick.md
@@ -428,6 +428,10 @@ For instructions, see the Ventoy documentation: [Start to use Ventoy](https://ww
 
 Ventoy is available for Linux and Microsoft Windows.
 
+:::{warning}
+Ventoy 1.1.11 (released Apr 2026) has a [known issue](https://github.com/ventoy/Ventoy/issues/3567) that prevents Ubuntu from installing correctly. We recommend using a previous Ventoy release or another USB creation tool.
+:::
+
 (image-writers-etcher)=
 ### balenaEtcher
 


### PR DESCRIPTION
Added a warning about a known issue with Ventoy 1.1.11 affecting Ubuntu installations.

I also considered linking to the launchpad bug instead: https://launchpad.net/bugs/2149811 , whichever feels better.