### PR TITLE
Revise warning for Ventoy 1.1.11 issue

### DIFF
--- a/docs/how-to/create-a-bootable-usb-stick.md
+++ b/docs/how-to/create-a-bootable-usb-stick.md
@@ -429,7 +429,7 @@ For instructions, see the Ventoy documentation: [Start to use Ventoy](https://ww
 Ventoy is available for Linux and Microsoft Windows.
 
 :::{warning}
-Ventoy 1.1.11 (released Apr 2026) has a [known issue](https://github.com/ventoy/Ventoy/issues/3567) that prevents Ubuntu from installing correctly. We recommend using a previous Ventoy release or another USB creation tool.
+Ventoy 1.1.11 (released Apr 2026) has a [known issue](https://github.com/ventoy/Ventoy/issues/3567) that prevents Ubuntu from installing correctly. We recommend using a different Ventoy release or another USB creation tool.
 :::
 
 (image-writers-etcher)=


### PR DESCRIPTION
Updated warning about Ventoy 1.1.11 to suggest using a "different" release instead of a "previous" release to reflect that Ventoy 1.1.12 is out with the issue fixed.

