### PR TITLE
TPM/FDE: Relax the hw root of trust requirement

### DIFF
--- a/docs/explanation/hardware-backed-disk-encryption.md
+++ b/docs/explanation/hardware-backed-disk-encryption.md
@@ -87,7 +87,7 @@ When using recovery keys for other platforms, see the relevant vendor’s docume
 
 Optionally, you can set a PIN or passphrase. You enter them every time your computer starts. The PIN is a numeric code while the passphrase is an alphanumerical password.
 
-You can enable, change and disable the PIN or passphrase in the Security Center app.
+You can enable, change and disable the PIN or passphrase in the Security Center app. However, if your system doesn't provide a hardware root of trust, TPM/FDE will always require that you set a PIN or passphrase to ensure a level of security.
 
 ### PIN and passphrase protection
 

--- a/docs/explanation/hardware-backed-disk-encryption.md
+++ b/docs/explanation/hardware-backed-disk-encryption.md
@@ -43,9 +43,7 @@ If you lose your recovery key, you might lose access to your data in certain sce
 
 You need the recovery key in several different situations:
 
-<!-- To be implemented:
 * If you **move your disk** to a new computer, you need to enter your recovery key before your new computer can access the data.
--->
 
 * If you **forget your disk PIN or passphrase**, Ubuntu asks for your recovery key to unlock the disk.
 

--- a/docs/explanation/hardware-backed-disk-encryption.md
+++ b/docs/explanation/hardware-backed-disk-encryption.md
@@ -87,7 +87,9 @@ When using recovery keys for other platforms, see the relevant vendor’s docume
 
 Optionally, you can set a PIN or passphrase. You enter them every time your computer starts. The PIN is a numeric code while the passphrase is an alphanumerical password.
 
-You can enable, change and disable the PIN or passphrase in the Security Center app. However, if your system doesn't provide a hardware root of trust, TPM/FDE will always require that you set a PIN or passphrase to ensure a level of security.
+You can enable, change and disable the PIN or passphrase in the Security Center app.
+
+If your system doesn't provide a hardware root of trust, the Ubuntu installer requires that you set a PIN or passphrase to ensure a level of security. You can disable it after installation.
 
 ### PIN and passphrase protection
 

--- a/docs/how-to/configure-hardware-backed-disk-encryption.md
+++ b/docs/how-to/configure-hardware-backed-disk-encryption.md
@@ -12,7 +12,7 @@ On an Ubuntu installation where the hardware-backed disk encryption (TPM/FDE) is
 (tpm-fde-set-passphrase)=
 ## Set a disk encryption PIN or passphrase
 
-For an additional layer of security, you can add an encryption PIN or passphrase. You enter them every time your computer starts up to unlock the disk. A PIN or passphrase is also required on systems that don't provide a hardware root of trust.
+For an additional layer of security, you can add an encryption PIN or passphrase. You enter them every time your computer starts up to unlock the disk. A PIN or passphrase is also required on systems that don't provide a hardware root of trust, though you can disable it afterward.
 
 To learn when you might want to enable the PIN or passphrase, see {ref}`tpm-fde-encryption-passphrase`.
 

--- a/docs/how-to/configure-hardware-backed-disk-encryption.md
+++ b/docs/how-to/configure-hardware-backed-disk-encryption.md
@@ -12,7 +12,7 @@ On an Ubuntu installation where the hardware-backed disk encryption (TPM/FDE) is
 (tpm-fde-set-passphrase)=
 ## Set a disk encryption PIN or passphrase
 
-For an additional layer of security, you can add an encryption PIN or passphrase. You enter them every time your computer starts up to unlock the disk.
+For an additional layer of security, you can add an encryption PIN or passphrase. You enter them every time your computer starts up to unlock the disk. A PIN or passphrase is also required on systems that don't provide a hardware root of trust.
 
 To learn when you might want to enable the PIN or passphrase, see {ref}`tpm-fde-encryption-passphrase`.
 

--- a/docs/how-to/encrypt-your-disk-with-tpm.md
+++ b/docs/how-to/encrypt-your-disk-with-tpm.md
@@ -28,7 +28,7 @@ To install Ubuntu with hardware-backed encryption:
     
 1. Check if the installer reports any errors.
 
-    Your system might not support all the required security features. In that case, the installer doesn't allow you to proceed with TPM/FDE. For more information, refer to {ref}`hardware-backed-disk-encryption-requirements`.
+    Your system might not support all the required security features. In that case, the installer doesn't allow you to proceed with TPM/FDE, or it requires that you set a PIN or a passphrase. For more information, refer to {ref}`hardware-backed-disk-encryption-requirements`.
 
     In some cases, your system isn't configured for TPM/FDE but it's possible to reconfigure it. The Ubuntu installer suggests automated or manual actions to resolve this. Some actions might require you to reboot the system to apply the modifications in the firmware.
 
@@ -44,7 +44,7 @@ To install Ubuntu with hardware-backed encryption:
     If you lose your recovery key, you might lose access to your data in certain scenarios. While you're logged in, replace the existing recovery key as soon as possible. See {ref}`tpm-fde-get-a-new-recovery-key`.
     :::
 
-1. After starting your new Ubuntu Desktop system, you can optionally {ref}`tpm-fde-set-passphrase`.
+1. After starting your new Ubuntu Desktop system, you can {ref}`configure a disk encryption PIN or passphrase <tpm-fde-set-passphrase>`.
 
 ## Configure the encryption after installation
 

--- a/docs/reference/hardware-backed-disk-encryption-requirements.md
+++ b/docs/reference/hardware-backed-disk-encryption-requirements.md
@@ -4,7 +4,7 @@
 (hardware-backed-disk-encryption-requirements)=
 # Hardware-backed disk encryption requirements
 
-Ubuntu checks certain system requirements before it allows you to enable {ref}`hardware-backed disk encryption <hardware-backed-disk-encryption>` (TPM/FDE) on your system. Generally, **most systems based on Intel and AMD processors made since 2018** are compatible with TPM/FDE. On most systems made since 2021, the disk can unlock automatically.
+Ubuntu checks certain system requirements before it allows you to enable {ref}`hardware-backed disk encryption <hardware-backed-disk-encryption>` (TPM/FDE) on your system. Generally, **most systems based on Intel and AMD processors made since 2018** are compatible with TPM/FDE. On most systems made since 2021, the disk can unlock automatically by default.
 
 ```{include} /reuse/tpm-fde-disclaimer.txt
 ```
@@ -37,7 +37,8 @@ The Ubuntu installer alerts you to this. You can choose to disable the feature i
 
 With a hardware root of trust, your hardware verifies the UEFI firmware before the firmware runs, based on a read-only piece of code in your CPU. This protects your disk encryption against threats such as malware that targets your firmware, or supply-chain attacks while your hardware is handled after manufacture.
 
-If your system does not have a hardware root of trust, the TPM/FDE makes it mandatory to add a PIN or passphrase.
+If your system does not have a hardware root of trust, the Ubuntu installer makes it mandatory to add a PIN or passphrase. After installation, you can disable the PIN or passphrase. However, your system won't be protected against the described hardware and firmware threats.
+
 
 ## Report bugs
 

--- a/docs/reference/hardware-backed-disk-encryption-requirements.md
+++ b/docs/reference/hardware-backed-disk-encryption-requirements.md
@@ -20,28 +20,26 @@ Your hardware must meet the following requirements to support TPM/FDE:
 
 - Secure Boot is enabled and in Deployed Mode.
 
-- The UEFI firmware is verified or at least measured by a hardware root of trust.
-
-    To verify or measure the firmware, your device must feature a dedicated security chip:
-
-    - The Boot Guard Authenticated Code Module (ACM) on Intel systems. Forced verification is required for now.
-    - Platform Secure Boot (PSB) enabled on AMD systems.
-
-    :::{note}
-    Certain hardware vendors might enable firmware options that alter your system's chain of trust, such as the [Absolute Persistence](https://www.absolute.com/platform/persistence) technology.
-
-    The Ubuntu installer alerts you to this. You can choose to disable the feature if you have the permissions or you can ignore the notice to keep the feature enabled.
-    :::
-
-## Strict security requirements
+## Careful security requirements
 
 Most of the listed TPM/FDE requirements are widely supported by the majority of PCs made since 2018. Other hardware-backed disk encryption solutions, such as BitLocker on Microsoft Windows, require a similar set of hardware features.
 
-However, TPM/FDE on Ubuntu also checks for a **hardware root of trust**. This final requirement is much stricter than with the other solutions. It raises the requirements to PCs made since 2021, in general.
+However, for TPM/FDE the Ubuntu installer also checks if the UEFI firmware is verified or at least measured by a **hardware root of trust** (which is generally the case for PCs made since 2021).
+
+To verify or measure the firmware, your device must feature a dedicated security chip:
+
+- The Boot Guard Authenticated Code Module (ACM) on Intel systems.
+- Platform Secure Boot (PSB) enabled on AMD systems.
+
+:::{note}
+Certain hardware vendors might enable firmware options that alter your system's chain of trust, such as the [Absolute Persistence](https://www.absolute.com/platform/persistence) technology.
+
+The Ubuntu installer alerts you to this. You can choose to disable the feature if you have the permissions or you can ignore the notice to keep the feature enabled.
+:::
 
 With a hardware root of trust, your hardware verifies the UEFI firmware before the firmware runs, based on a read-only piece of code in your CPU. This protects your disk encryption against threats such as malware that targets your firmware, or supply-chain attacks while your hardware is handled after manufacture.
 
-As a consequence of this security requirement, Ubuntu with TPM/FDE can't be installed on certain systems that support BitLocker on Microsoft Windows.
+For this reason and in order to keep a good level of security, if your systems does not have a hardware root of trust, the Ubuntu installer makes it mandatory to add a PIN or passphrase.
 
 ## Report bugs
 

--- a/docs/reference/hardware-backed-disk-encryption-requirements.md
+++ b/docs/reference/hardware-backed-disk-encryption-requirements.md
@@ -22,7 +22,7 @@ Your hardware must meet the following requirements to support TPM/FDE:
 
 ## Automatic unlocking
 
-Your disk can unlock automatically without a passphrase or a PIN if the UEFI firmware is verified or measured by a **hardware root of trust**. This is generally the case for PCs made since 2021. Automatic unlocking is also known as *TPM-only unlock*.
+Your disk can unlock automatically without a PIN or passphrase if the UEFI firmware is verified or measured by a **hardware root of trust**. This is generally the case for PCs made since 2021. Automatic unlocking is also known as *TPM-only unlock*.
 
 To verify or measure the firmware, your device must feature a dedicated security chip:
 

--- a/docs/reference/hardware-backed-disk-encryption-requirements.md
+++ b/docs/reference/hardware-backed-disk-encryption-requirements.md
@@ -4,7 +4,7 @@
 (hardware-backed-disk-encryption-requirements)=
 # Hardware-backed disk encryption requirements
 
-Ubuntu checks certain system requirements before it allows you to enable {ref}`hardware-backed disk encryption <hardware-backed-disk-encryption>` (TPM/FDE) on your system. Generally, **most systems based on Intel and AMD processors made since 2021** are compatible with TPM/FDE. However, the requirements are stricter than with other disk encryption solutions, such as BitLocker on Windows.
+Ubuntu checks certain system requirements before it allows you to enable {ref}`hardware-backed disk encryption <hardware-backed-disk-encryption>` (TPM/FDE) on your system. Generally, **most systems based on Intel and AMD processors made since 2018** are compatible with TPM/FDE. On most systems made since 2021, the disk can unlock automatically.
 
 ```{include} /reuse/tpm-fde-disclaimer.txt
 ```
@@ -20,11 +20,9 @@ Your hardware must meet the following requirements to support TPM/FDE:
 
 - Secure Boot is enabled and in Deployed Mode.
 
-## Careful security requirements
+## Automatic unlocking
 
-Most of the listed TPM/FDE requirements are widely supported by the majority of PCs made since 2018. Other hardware-backed disk encryption solutions, such as BitLocker on Microsoft Windows, require a similar set of hardware features.
-
-However, for TPM/FDE the Ubuntu installer also checks if the UEFI firmware is verified or at least measured by a **hardware root of trust** (which is generally the case for PCs made since 2021).
+Your disk can unlock automatically without a passphrase or a PIN if the UEFI firmware is verified or measured by a **hardware root of trust**. This is generally the case for PCs made since 2021. Automatic unlocking is also known as *TPM-only unlock*.
 
 To verify or measure the firmware, your device must feature a dedicated security chip:
 
@@ -39,7 +37,7 @@ The Ubuntu installer alerts you to this. You can choose to disable the feature i
 
 With a hardware root of trust, your hardware verifies the UEFI firmware before the firmware runs, based on a read-only piece of code in your CPU. This protects your disk encryption against threats such as malware that targets your firmware, or supply-chain attacks while your hardware is handled after manufacture.
 
-For this reason and in order to keep a good level of security, if your systems does not have a hardware root of trust, the Ubuntu installer makes it mandatory to add a PIN or passphrase.
+If your systems does not have a hardware root of trust, the Ubuntu installer makes it mandatory to add a PIN or passphrase.
 
 ## Report bugs
 

--- a/docs/reference/hardware-backed-disk-encryption-requirements.md
+++ b/docs/reference/hardware-backed-disk-encryption-requirements.md
@@ -37,7 +37,7 @@ The Ubuntu installer alerts you to this. You can choose to disable the feature i
 
 With a hardware root of trust, your hardware verifies the UEFI firmware before the firmware runs, based on a read-only piece of code in your CPU. This protects your disk encryption against threats such as malware that targets your firmware, or supply-chain attacks while your hardware is handled after manufacture.
 
-If your systems does not have a hardware root of trust, the Ubuntu installer makes it mandatory to add a PIN or passphrase.
+If your system does not have a hardware root of trust, the TPM/FDE makes it mandatory to add a PIN or passphrase.
 
 ## Report bugs
 


### PR DESCRIPTION
For TPM/FDE, the hardware root of trust is no longer a requirement for the system. But if it is missing, the Ubuntu installer makes it mandatory to set an additional PIN or passphrase.