### PR TITLE
Improve README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Vale style checks](https://github.com/ubuntu/ubuntu-desktop-documentation/actions/workflows/vale-style.yaml/badge.svg)](https://github.com/ubuntu/ubuntu-desktop-documentation/actions/workflows/vale-style.yaml)
 [![Automatic doc checks](https://github.com/ubuntu/ubuntu-desktop-documentation/actions/workflows/automatic-doc-checks.yml/badge.svg)](https://github.com/ubuntu/ubuntu-desktop-documentation/actions/workflows/automatic-doc-checks.yml)
 
-This is a repository with documentation for the Ubuntu Desktop product.
+This repository contains documentation for the Ubuntu Desktop product.
 
 It's written in Markdown and built with the Sphinx and Read the Docs frameworks.
 


### PR DESCRIPTION
Description

Improved the wording in the README to make the description of the repository clearer and more natural.

Changed:
"This is a repository with documentation for the Ubuntu Desktop product."

To:
"This repository contains documentation for the Ubuntu Desktop product."